### PR TITLE
Add wrap-up scene

### DIFF
--- a/shell.html
+++ b/shell.html
@@ -20,6 +20,22 @@
   <div id="sceneLog" class="container-medium"></div>
   <button id="nextBtn" class="button">Next</button>
 
+  <div id="wrapUpScene" class="hidden">
+    <h2>Your Dashboard</h2>
+    <div id="wrapBrands" class="brand-tiles"></div>
+    <div id="summaryArea">
+      <p>Total ASK earned: <span id="totalAsk">0</span></p>
+      <p id="recentActivity"></p>
+    </div>
+    <div id="wrapMessages">
+      <p class="overlay-text">It’s not ads.</p>
+      <p class="overlay-text">It’s not spam.</p>
+      <p class="overlay-text">It’s your life — supported.</p>
+    </div>
+    <p>Come for the rewards. Stay for the brands that get you.</p>
+    <p id="branding"><strong>Permission x Google – Zero-party data. Trusted by users. Powered by AI.</strong></p>
+  </div>
+
   <script src="shell.js"></script>
 </body>
 </html>

--- a/shell.js
+++ b/shell.js
@@ -17,14 +17,8 @@ const scenes = [
     'Scene three continues the story.',
     'Keep the pacing steady for your audience.'
   ]},
-  {name: 'Scene 4', lines: [
-    'Almost done! This is scene four.',
-    'Wrap up any remaining details.'
-  ]},
-  {name: 'End', lines: [
-    'Thanks for watching the demo.',
-    'Feel free to restart if you would like to see it again.'
-  ]}
+  // The final scene displays a custom UI rather than scripted lines
+  {name: 'Scene 4 - Wrap-Up', lines: []}
 ];
 
 let sceneIndex = 0;
@@ -33,6 +27,10 @@ let lineIndex = 0;
 const sceneName = q('sceneName');
 const sceneLog = q('sceneLog');
 const nextBtn = q('nextBtn');
+const wrapScene = q('wrapUpScene');
+const wrapBrands = q('wrapBrands');
+const totalAskEl = q('totalAsk');
+const recentActivityEl = q('recentActivity');
 
 function append(text){
   const p = document.createElement('p');
@@ -41,20 +39,60 @@ function append(text){
   sceneLog.scrollTop = sceneLog.scrollHeight;
 }
 
+function parseAsk(str){
+  const m = /(\d+)\s*ASK/i.exec(str || '');
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+function updateWrapUp(){
+  const brands = JSON.parse(localStorage.getItem('optedInBrands') || '[]');
+  wrapBrands.innerHTML = '';
+  brands.forEach(b => {
+    const div = document.createElement('div');
+    div.className = 'tile card';
+    div.textContent = b;
+    wrapBrands.appendChild(div);
+  });
+  const offers = JSON.parse(localStorage.getItem('offers') || '[]');
+  let total = 0;
+  offers.forEach(o => { total += parseAsk(o.reward); });
+  totalAskEl.textContent = total;
+  if(offers.length){
+    const last = offers[offers.length-1];
+    recentActivityEl.textContent = last.brand + ': ' + last.reward;
+  } else {
+    recentActivityEl.textContent = 'No recent activity';
+  }
+}
+
 function showScene(){
   sceneName.textContent = scenes[sceneIndex].name;
-  sceneLog.innerHTML = '';
   lineIndex = 0;
+  if(sceneIndex === scenes.length - 1){
+    // Final wrap-up scene
+    sceneLog.classList.add('hidden');
+    wrapScene.classList.remove('hidden');
+    nextBtn.textContent = 'Replay Demo';
+    nextBtn.onclick = () => window.location.reload();
+    updateWrapUp();
+  } else {
+    sceneLog.classList.remove('hidden');
+    wrapScene.classList.add('hidden');
+    sceneLog.innerHTML = '';
+    nextBtn.textContent = 'Next';
+    nextBtn.onclick = next;
+  }
 }
 
 function next(){
   const scene = scenes[sceneIndex];
+  if(sceneIndex === scenes.length - 1){
+    // Final scene handled by showScene()
+    return;
+  }
   if(lineIndex < scene.lines.length){
     append(scene.lines[lineIndex]);
     lineIndex++;
-    if(sceneIndex === scenes.length - 1 && lineIndex === scene.lines.length){
-      nextBtn.textContent = 'Done';
-    }
   } else {
     sceneIndex++;
     if(sceneIndex < scenes.length){

--- a/style.css
+++ b/style.css
@@ -199,3 +199,25 @@ input[type="file"]:focus-visible {
 
 .step { border: 1px solid #ccc; padding: 20px; margin-bottom: 20px; }
 
+/* Wrap-up scene styles */
+#wrapUpScene {
+  margin-top: 20px;
+}
+
+.brand-tiles {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+}
+
+.overlay-text {
+  font-size: 20px;
+  font-weight: bold;
+  margin: 10px 0;
+}
+
+#branding {
+  margin-top: 20px;
+}
+


### PR DESCRIPTION
## Summary
- create new wrap-up scene in the presenter shell
- show opted-in brands and earnings summary
- display brand messaging and replay option

## Testing
- `npm test` *(fails: Could not read package.json)*