### PR TITLE
Fix income modal visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -161,6 +161,10 @@ input[type="file"]:focus-visible {
   justify-content: center;
   align-items: center;
 }
+.modal-overlay.hidden {
+  display: none;
+}
+
 
 .modal-content {
   background: #FFFFFF;


### PR DESCRIPTION
## Summary
- ensure the income modal is hidden by default by adding a specific rule

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest` *(fails: command not found)*