### PR TITLE
Add DOM-based flow tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "testing-chickens",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/test/fake-dom.js
+++ b/test/fake-dom.js
@@ -1,0 +1,80 @@
+class FakeClassList {
+  constructor() { this.classes = new Set(); }
+  add(...cls) { cls.forEach(c => this.classes.add(c)); }
+  remove(...cls) { cls.forEach(c => this.classes.delete(c)); }
+  contains(c) { return this.classes.has(c); }
+  toString() { return Array.from(this.classes).join(' '); }
+}
+
+class FakeElement {
+  constructor(tag, id, document) {
+    this.tagName = tag.toLowerCase();
+    this.id = id || null;
+    this.document = document;
+    this.children = [];
+    this.parent = null;
+    this.classList = new FakeClassList();
+    this.style = {};
+    this.onclick = null;
+    this.textContent = '';
+    this._innerHTML = '';
+    this._listeners = {};
+  }
+  appendChild(el) { el.parent = this; this.children.push(el); }
+  removeChild(el) { this.children = this.children.filter(c => c !== el); }
+  remove() { if(this.parent) this.parent.removeChild(this); }
+  querySelector(selector) {
+    if(selector.startsWith('#')) return this.document.getElementById(selector.slice(1));
+    if(selector === 'button') {
+      const stack = [...this.children];
+      while(stack.length) {
+        const el = stack.shift();
+        if(el.tagName === 'button') return el;
+        stack.push(...el.children);
+      }
+    }
+    return null;
+  }
+  addEventListener(event, cb) {
+    this._listeners[event] = this._listeners[event] || [];
+    this._listeners[event].push(cb);
+  }
+  click() {
+    if(this.onclick) this.onclick();
+    const list = this._listeners['click'] || [];
+    list.forEach(cb => cb());
+  }
+  set innerHTML(v) { this._innerHTML = v; this.children = []; }
+  get innerHTML() { return this._innerHTML; }
+}
+
+class FakeDocument {
+  constructor() { this.elements = {}; this.body = new FakeElement('body', 'body', this); }
+  createElement(tag) { return new FakeElement(tag, null, this); }
+  getElementById(id) { return this.elements[id] || null; }
+}
+
+function makeDOM(ids) {
+  const document = new FakeDocument();
+  const window = { location: { search: '', href: '', reload: () => {} } };
+  ids.forEach(id => {
+    const tag = id.toLowerCase().includes('btn') ? 'button' :
+      (id === 'demoFrame' ? 'iframe' : 'div');
+    const el = new FakeElement(tag, id, document);
+    document.elements[id] = el;
+    document.body.appendChild(el);
+  });
+  return { document, window };
+}
+
+function makeStorage() {
+  const store = {};
+  return {
+    getItem(k) { return Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null; },
+    setItem(k, v) { store[k] = String(v); },
+    removeItem(k) { delete store[k]; },
+    clear() { for (const k in store) delete store[k]; }
+  };
+}
+
+module.exports = { makeDOM, makeStorage, FakeElement };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,92 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const { makeDOM, makeStorage } = require('./fake-dom');
+
+function runScript(file, env) {
+  const code = fs.readFileSync(file, 'utf8');
+  vm.runInContext(code, env);
+  if (env.window.onload) env.window.onload();
+}
+
+test('user page flow progresses to verification', () => {
+  const ids = ['chatLog','chat','landing','dashboard','optInBtn','featuredBrand','nextBtn','minChatBtn','openChatBtn','incomeModal','verifyCompleteBtn','sceneNextBtn','brands','offers'];
+  const { document, window } = makeDOM(ids);
+  const context = vm.createContext({
+    window,
+    document,
+    localStorage: makeStorage(),
+    sessionStorage: makeStorage(),
+    URLSearchParams,
+    setInterval: () => {},
+    setTimeout: (fn) => fn(),
+    console
+  });
+  runScript('script.js', context);
+
+  document.getElementById('optInBtn').onclick();
+  const nextBtn = document.getElementById('nextBtn');
+  for (let i = 0; i < 5; i++) nextBtn.onclick();
+  document.getElementById('verifyCompleteBtn').onclick();
+
+  assert(!document.getElementById('sceneNextBtn').classList.contains('hidden'));
+});
+
+test('brand portal flow reaches go live', () => {
+  const ids = [
+    'chatLog','nextBtn','wizard','step1','step1Next','step2','step2Next',
+    'step3','launchBtn','audienceInput','adHeadline','adCopy','previewHeadline',
+    'previewBody','summary','minChatBtn','openChatBtn'
+  ];
+  const { document, window } = makeDOM(ids);
+  const context = vm.createContext({
+    window,
+    document,
+    localStorage: makeStorage(),
+    URLSearchParams,
+    setTimeout: (fn) => fn(),
+    console
+  });
+  const html = fs.readFileSync('brand.html','utf8');
+  const match = /<script>([\s\S]*?)<\/script>/m.exec(html);
+  vm.runInContext(match[1], context);
+  if (window.onload) window.onload();
+
+  const nextBtn = document.getElementById('nextBtn');
+  nextBtn.onclick();
+  nextBtn.onclick();
+  const openBuilder = document.getElementById('chatLog').querySelector('button');
+  openBuilder.onclick();
+  nextBtn.onclick();
+  document.getElementById('step1Next').onclick();
+  document.getElementById('step2Next').onclick();
+  document.getElementById('launchBtn').onclick();
+  const goBtn = document.getElementById('summary').children[0];
+  goBtn.onclick();
+  const nextSummary = document.getElementById('summary').children[0];
+  nextSummary.onclick();
+
+  const offers = JSON.parse(context.localStorage.getItem('offers'));
+  assert(offers && offers.length === 1);
+  assert(window.location.href.includes('scene=final'));
+});
+
+test('shell scene progression', () => {
+  const ids = ['sceneName','sceneLog','nextBtn','demoFrame','wrapUpScene','wrapBrands','totalAsk','recentActivity','introScreen'];
+  const { document, window } = makeDOM(ids);
+  const context = vm.createContext({
+    window,
+    document,
+    localStorage: makeStorage(),
+    URLSearchParams,
+    setTimeout: (fn) => fn(),
+    console
+  });
+  runScript('shell.js', context);
+
+  const nextBtn = document.getElementById('nextBtn');
+  for (let i = 0; i < 4; i++) nextBtn.click();
+
+  assert.strictEqual(document.getElementById('sceneName').textContent, 'Scene 4 - Wrap-Up');
+});


### PR DESCRIPTION
## Summary
- add Node-based test setup and fake DOM helpers
- check progression for user flow, brand portal, and shell scenes
- define npm test script for running these on PRs

## Testing
- `npm test`