### PR TITLE
Add missing ad preview step and chat flow

### DIFF
--- a/brand.html
+++ b/brand.html
@@ -39,9 +39,14 @@
       <div id="step3" class="step hidden">
         <h2>Preview Ad</h2>
         <div class="tile card preview-ad">
+          <img id="previewImg" class="image-responsive" alt="Ad preview">
           <h3 id="previewHeadline"></h3>
           <p id="previewBody"></p>
         </div>
+        <button id="step3Next" class="button">Next</button>
+      </div>
+      <div id="step4" class="step hidden">
+        <h2>Launch Campaign</h2>
         <button id="launchBtn" class="button">Launch Campaign</button>
       </div>
     </div>
@@ -58,6 +63,8 @@
   const wizard = document.getElementById('wizard');
   const step1Next = document.getElementById('step1Next');
   const step2Next = document.getElementById('step2Next');
+  const step3Next = document.getElementById('step3Next');
+  const previewImg = document.getElementById('previewImg');
   const launchBtn = document.getElementById('launchBtn');
   const audienceInput = document.getElementById('audienceInput');
   const adHeadlineEl = document.getElementById('adHeadline');
@@ -155,11 +162,17 @@
 
   step2Next.onclick = () => {
     document.getElementById('step2').classList.add('hidden');
+    previewImg.src = document.getElementById('creativeImg').src;
     document.getElementById('step3').classList.remove('hidden');
   };
 
-  launchBtn.onclick = () => {
+  step3Next.onclick = () => {
     document.getElementById('step3').classList.add('hidden');
+    document.getElementById('step4').classList.remove('hidden');
+  };
+
+  launchBtn.onclick = () => {
+    document.getElementById('step4').classList.add('hidden');
     wizard.classList.add('hidden');
     handleNext();
   };
@@ -208,6 +221,7 @@
       () => nextBtn.click(),
       () => step1Next.click(),
       () => step2Next.click(),
+      () => step3Next.click(),
       () => launchBtn.click(),
       () => nextBtn.click()
     ];

--- a/script.js
+++ b/script.js
@@ -223,7 +223,7 @@ window.onload = function(){
   if(featuredBrandEl) featuredBrandEl.textContent = featuredBrand;
   updateDashboard();
   setInterval(checkOffers, 3000);
-  if(scene === 'final' && demo){
+  if(scene === 'final'){
     showChat();
   }
   if(demo && scene !== 'final'){

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -36,8 +36,8 @@ test('user page flow progresses to verification', () => {
 test('brand portal flow reaches go live', () => {
   const ids = [
     'chatLog','nextBtn','wizard','step1','step1Next','step2','step2Next',
-    'step3','launchBtn','audienceInput','adHeadline','adCopy','previewHeadline',
-    'previewBody','summary','minChatBtn','openChatBtn'
+    'step3','step3Next','step4','launchBtn','audienceInput','adHeadline','adCopy',
+    'previewHeadline','previewBody','previewImg','creativeImg','summary','minChatBtn','openChatBtn'
   ];
   const { document, window } = makeDOM(ids);
   const context = vm.createContext({
@@ -61,6 +61,7 @@ test('brand portal flow reaches go live', () => {
   nextBtn.onclick();
   document.getElementById('step1Next').onclick();
   document.getElementById('step2Next').onclick();
+  document.getElementById('step3Next').onclick();
   document.getElementById('launchBtn').onclick();
   const goBtn = document.getElementById('summary').children[0];
   goBtn.onclick();


### PR DESCRIPTION
## Summary
- add dedicated preview step to brand portal with Next button
- show ad image on the preview step
- ensure chat auto-opens when returning to dashboard
- update tests for new preview step

## Testing
- `npm test`