### PR TITLE
Improve demo button flow

### DIFF
--- a/brand.html
+++ b/brand.html
@@ -74,7 +74,11 @@
   const summary = document.getElementById('summary');
   const minChatBtn = document.getElementById('minChatBtn');
   const openChatBtn = document.getElementById('openChatBtn');
+  let actionBtn = null;
   nextBtn.onclick = handleNext;
+
+  function hideNext(){ nextBtn.classList.add('hidden'); }
+  function showNext(){ nextBtn.classList.remove('hidden'); }
 
   const brandNames = ['Bambino Diapers','Happy Tush','SnugBug','EcoBaby','SoftCare'];
   const brand = brandNames[Math.floor(Math.random()*brandNames.length)];
@@ -108,26 +112,34 @@
   }
 
   function showWizardButton(){
+    hideNext();
+    if(actionBtn) actionBtn.remove();
     const btn = document.createElement('button');
     btn.className = 'button';
     btn.textContent = 'Open Builder';
     btn.onclick = () => {
       btn.remove();
+      actionBtn = null;
       showWizard();
       pair++;
       expecting = 'ai';
     };
+    actionBtn = btn;
     log.appendChild(btn);
   }
 
   function handleNext(){
-    if(pair >= conversation.length) return;
+    if(pair >= conversation.length){
+      hideNext();
+      return;
+    }
     const curr = conversation[pair];
     if(expecting === 'user'){
       if(curr.user){
         append(curr.user, 'user');
         pair++;
         if(pair === conversation.length){
+          hideNext();
           showOfferSummary(curr.user);
         }
         expecting = 'ai';
@@ -174,6 +186,7 @@
   launchBtn.onclick = () => {
     document.getElementById('step4').classList.add('hidden');
     wizard.classList.add('hidden');
+    hideNext();
     handleNext();
   };
 
@@ -237,6 +250,7 @@
 
   window.onload = () => {
     append(conversation[0].ai, 'ai');
+    showNext();
     if(demo){
       setTimeout(guidedDemo, 500);
     }

--- a/script.js
+++ b/script.js
@@ -16,6 +16,10 @@ const openChatBtn = q('openChatBtn');
 const incomeModal = q('incomeModal');
 const verifyCompleteBtn = q('verifyCompleteBtn');
 const sceneNextBtn = q('sceneNextBtn');
+let actionBtn = null;
+
+function hideNext(){ nextBtn.classList.add('hidden'); }
+function showNext(){ nextBtn.classList.remove('hidden'); }
 
 const featuredBrand = 'Diaper Brand #1';
 
@@ -73,10 +77,13 @@ function startChat(){
   showChat();
   pair = 0;
   expecting = 'user';
+  showNext();
   append(conversation[0].ai, 'ai');
 }
 
 function showVerify(){
+  hideNext();
+  if(actionBtn) actionBtn.remove();
   const btn = document.createElement('button');
   btn.className = 'button';
   btn.textContent = 'Verify Now';
@@ -84,10 +91,14 @@ function showVerify(){
     incomeModal.classList.remove('hidden');
   };
   chatLog.appendChild(btn);
+  actionBtn = btn;
 }
 
 function handleNext(){
-  if(pair >= conversation.length) return;
+  if(pair >= conversation.length){
+    hideNext();
+    return;
+  }
   const curr = conversation[pair];
   if(expecting === 'user'){
     if(curr.user){
@@ -112,6 +123,11 @@ verifyCompleteBtn.onclick = () => {
   badge.textContent = 'ASK';
   chatLog.appendChild(badge);
   chatLog.appendChild(document.createElement('br'));
+  if(actionBtn){
+    actionBtn.remove();
+    actionBtn = null;
+  }
+  hideNext();
   sceneNextBtn.classList.remove('hidden');
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,7 +58,6 @@ test('brand portal flow reaches go live', () => {
   nextBtn.onclick();
   const openBuilder = document.getElementById('chatLog').querySelector('button');
   openBuilder.onclick();
-  nextBtn.onclick();
   document.getElementById('step1Next').onclick();
   document.getElementById('step2Next').onclick();
   document.getElementById('step3Next').onclick();
@@ -116,5 +115,5 @@ test('only one chat button active at a time', () => {
   assert.strictEqual(countButtons(), 1);
 
   document.getElementById('verifyCompleteBtn').onclick();
-  assert.strictEqual(countButtons(), 1);
+  assert.strictEqual(countButtons(), 0);
 });


### PR DESCRIPTION
## Summary
- only show one actionable chat button at a time on the user page
- hide the main Next button when the brand page wizard is active
- update tests for new flow

## Testing
- `npm test`