### PR TITLE
Add dashboard transition and update final screen text

### DIFF
--- a/demo-v2.html
+++ b/demo-v2.html
@@ -432,11 +432,9 @@ input[type="file"]:focus-visible {
   <h3>Earn History</h3>
   <ul id="earnEvents"></ul>
   <div id="wrapMessages">
-    <p class="overlay-text">It’s not ads.</p>
-    <p class="overlay-text">It’s not spam.</p>
-    <p class="overlay-text">It’s your life — supported.</p>
+    <p class="overlay-text">Permission x Google</p>
+    <p class="overlay-text">Zero-party data. Trusted by users. Powered by AI.</p>
   </div>
-  <p>Come for the rewards. Stay for the brands that get you.</p>
   <p id="branding"><strong>Permission x Google – Zero-party data. Trusted by users. Powered by AI.</strong></p>
   <button id="restartBtn" class="button">Replay Demo</button>
 </div>

--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
     <h2>Your Dashboard</h2>
     <div id="brands"></div>
     <div id="offers"></div>
+    <button id="dashboardNextBtn" class="button">Next</button>
   </div>
 
   <div id="wrapUpScene" class="hidden container-medium">
@@ -51,11 +52,9 @@
       <p id="recentActivity"></p>
     </div>
     <div id="wrapMessages">
-      <p class="overlay-text">It’s not ads.</p>
-      <p class="overlay-text">It’s not spam.</p>
-      <p class="overlay-text">It’s your life — supported.</p>
+      <p class="overlay-text">Permission x Google</p>
+      <p class="overlay-text">Zero-party data. Trusted by users. Powered by AI.</p>
     </div>
-    <p>Come for the rewards. Stay for the brands that get you.</p>
     <p id="branding"><strong>Permission x Google – Zero-party data. Trusted by users. Powered by AI.</strong></p>
     <button id="restartBtn" class="button">Replay Demo</button>
   </div>

--- a/script.js
+++ b/script.js
@@ -21,6 +21,7 @@ const wrapBrands = q('wrapBrands');
 const totalAskEl = q('totalAsk');
 const recentActivityEl = q('recentActivity');
 const restartBtn = q('restartBtn');
+const dashNextBtn = q('dashboardNextBtn');
 let actionBtn = null;
 
 function hideNext(){ nextBtn.classList.add('hidden'); }
@@ -280,6 +281,10 @@ if(openChatBtn){
 
 if(restartBtn){
   restartBtn.onclick = () => window.location.href = 'demo.html';
+}
+
+if(dashNextBtn){
+  dashNextBtn.onclick = showWrapUp;
 }
 
 window.onload = function(){

--- a/shell.html
+++ b/shell.html
@@ -34,11 +34,9 @@
       <p id="recentActivity"></p>
     </div>
     <div id="wrapMessages">
-      <p class="overlay-text">It’s not ads.</p>
-      <p class="overlay-text">It’s not spam.</p>
-      <p class="overlay-text">It’s your life — supported.</p>
+      <p class="overlay-text">Permission x Google</p>
+      <p class="overlay-text">Zero-party data. Trusted by users. Powered by AI.</p>
     </div>
-    <p>Come for the rewards. Stay for the brands that get you.</p>
     <p id="branding"><strong>Permission x Google – Zero-party data. Trusted by users. Powered by AI.</strong></p>
   </div>
 


### PR DESCRIPTION
## Summary
- add a new **Next** button in the dashboard
- replace wrap-up copy with "Permission x Google" messaging
- wire the dashboard button to show the wrap-up scene

## Testing
- `npm test`
